### PR TITLE
Check point coordinate values to detect context menu key case

### DIFF
--- a/Src/DirFrame.cpp
+++ b/Src/DirFrame.cpp
@@ -535,7 +535,8 @@ LRESULT CDirFrame::OnWndMsg<WM_CONTEXTMENU>(WPARAM, LPARAM lParam)
 {
 	POINT point;
 	POINTSTOPOINT(point, lParam);
-	if (lParam == MAKELPARAM(-1, -1))
+	// Context menu opened using keyboard has no coordinates
+	if (point.x == -1 && point.y == -1)
 	{
 		point.x = point.y = 5;
 		m_pDirView->ClientToScreen(&point);


### PR DESCRIPTION
Using the context menu key shortcut or <kbd>Shift</kbd> + <kbd>F10</kbd> doesn't work in directory comparison view because it uses some incorrect checks for the keyboard shortcut case.

I was inspired by the following codes to fix the issue:

https://github.com/datadiode/winmerge2011/blob/51b93783be41570be36152cafbae579d9aa353e6/Src/MergeEditView.cpp#L798-L803

https://github.com/datadiode/winmerge2011/blob/51b93783be41570be36152cafbae579d9aa353e6/Src/MergeDiffDetailView.cpp#L335-L340

https://github.com/datadiode/winmerge2011/blob/51b93783be41570be36152cafbae579d9aa353e6/Src/LocationView.cpp#L633-L640

Fixes #18